### PR TITLE
Updates actions versions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,7 +9,8 @@ jobs:
       - name: set up JDK 1.8
         uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          java-version: 8
+          distribution: zulu
       - name: Run CI
         run: make ci
       - name: Upload SonarCloud

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,11 +13,6 @@ jobs:
           distribution: zulu
       - name: Run CI
         run: make ci
-      - name: Upload SonarCloud
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: make sonar
       - name: Upload artifact
         if: github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,9 +5,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 1.8
       - name: Run CI
@@ -19,7 +19,8 @@ jobs:
         run: make sonar
       - name: Upload artifact
         if: github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: google-analytics-dispatcher.zip
           path: release/
+          override: true


### PR DESCRIPTION
# Description

This PR updates the used version of few actions, especially "upload-artifact", as this version will be [decommissioned](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/)
